### PR TITLE
Fixed crash caused by improper copy of STL lists (sets, maps)

### DIFF
--- a/STL/List.hpp
+++ b/STL/List.hpp
@@ -2,6 +2,8 @@
 
 #include <stddef.h>
 
+#include "Logger.h"
+
 template <typename T>
 class List
 {
@@ -9,6 +11,9 @@ class List
 public:
 
    List();
+
+   List(
+      const List& copyObject);
 
    virtual ~List();
 
@@ -91,11 +96,25 @@ List<T>::List():
 {
 }
 
+// Copy constructor.
+template<class T>
+List<T>::List(
+   const List& copyObject) :
+      listSize(0),
+      startNode(NULL),
+      endNode(NULL)
+{
+   for (typename List<T>::Iterator it = copyObject.begin(); it != copyObject.end(); it++)
+   {
+      push_back(*it);
+   }
+}
+
 // Destructor.
 template<class T>
 List<T>::~List()
 {
-  clear();
+   clear();
 }
 
 // Get size
@@ -141,16 +160,16 @@ void List<T>::remove(
 template<class T>
 void List<T>::clear()
 {
-  Node* tmp = startNode;
-  while (startNode != NULL)
-  {
-    tmp = startNode;
-    startNode = startNode->next;
-    delete tmp; // Delete item
-    listSize--; // Decrease counter
-  }
+   Node* tmp = startNode;
+   while (startNode != NULL)
+   {
+      tmp = startNode;
+      startNode = startNode->next;
+      delete tmp; // Delete item
+      listSize--; // Decrease counter
+   }
   
-  endNode = NULL;
+   endNode = NULL;
 }
 
 // Assignment operator.

--- a/STL/Map.hpp
+++ b/STL/Map.hpp
@@ -15,6 +15,9 @@ public:
 
    Map();
 
+   Map(
+      const Map& copyObject);
+
    virtual ~Map();
 
    virtual bool isSet(const KEY& key) const;
@@ -57,6 +60,13 @@ private:
 template<typename KEY, typename VALUE>
 Map<KEY, VALUE>::Map()
 {  
+}
+
+template<typename KEY, typename VALUE>
+Map<KEY, VALUE>::Map(
+   const Map& copyObject) :
+      list(copyObject.list)
+{
 }
 
 template<typename KEY, typename VALUE>

--- a/STL/Set.hpp
+++ b/STL/Set.hpp
@@ -12,6 +12,9 @@ public:
 
    Set();
 
+   Set(
+      const Set& copyObject);
+
    virtual ~Set();
 
    virtual Iterator begin() const;
@@ -45,11 +48,21 @@ private:
    List<T> list;
 };
 
+// Constructor.
 template<typename T>
 Set<T>::Set()
 {  
 }
 
+// Copy constructor.
+template<class T>
+Set<T>::Set(
+   const Set& copyObject) :
+      list(copyObject.list)
+{
+}
+
+// Destructor.
 template<typename T>
 Set<T>::~Set()
 {

--- a/test/ListTest/ListTest.ino
+++ b/test/ListTest/ListTest.ino
@@ -1,0 +1,29 @@
+#include "Logger.h"
+#include "List.hpp"
+
+void setup()
+{
+   Serial.begin(9600);
+   Logger::setLogger(new SerialLogger());
+
+   Logger::logDebug("\n\n********** STL List Test **********\n\n");
+
+   List<int> list;
+
+   for (int i = 0; i < 10; i++)
+   {
+      list.push_back(i);
+   }
+
+   for (int i = 0; i < 10; i++)
+   {
+     for (List<int>::Iterator it = list.begin(); it != list.end(); it++)
+     {
+        Logger::logDebug("%d", *it);
+     }
+   }
+}
+
+void loop()
+{
+}

--- a/test/MapTest/MapTest.ino
+++ b/test/MapTest/MapTest.ino
@@ -1,0 +1,27 @@
+#include "Logger.h"
+#include "Map.hpp"
+#include "Set.hpp"
+
+void setup()
+{
+   Serial.begin(9600);
+   Logger::setLogger(new SerialLogger());
+
+   Logger::logDebug("\n\n********** STL Map Test **********\n\n");
+
+   Map<int, int> myMap;
+
+   for (int i = 0; i < 10; i++)
+   {
+      myMap[i] = (i * 2);
+   }
+
+   for (Map<int, int>::Iterator it = myMap.begin(); it != myMap.end(); it++)
+   {
+      Logger::logDebug("%d:%d", it->first, it->second);
+   }
+}
+
+void loop()
+{
+}


### PR DESCRIPTION
List<int> intList = copyList

I assumed this used the assignment operator.  Nope.  Copy constructor.
Added copy constructors for List, Set, and Map.